### PR TITLE
Links `code-ui` on `develop`, builds and moves to `ui`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,9 @@ for:
       - master
   environment:
     NODE_ENV: production
+  install:
+    - cmd: npm ci --production
   build_script:
-    - cmd: npm config set production
-    - cmd: npm install
     - cmd: npm run move-ui-production
     - cmd: npm run bundle
     - cmd: npm run package
@@ -31,9 +31,15 @@ for:
       - develop
   environment:
     NODE_ENV: stage
+  install:
+      - cmd: git clone --single-branch --branch develop https://github.com/strawbees/code-ui.git
+      - cmd: cd code-ui
+      - cmd: npm link
+      - cmd: cd ..
+      - cmd: npm ci --production
   build_script:
-    - cmd: npm install
-    - cmd: npm run move-ui-stage
+    - cmd: npm run build-ui
+    - cmd: npm run move-ui-develop
     - cmd: npm run bundle
     - cmd: npm run package
 -

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "scripts": {
         "postinstall": "npm run install-src",
         "install-src": "cd src && npm install",
+        "build-ui": "CONFIG=web_stage strawbees-code-ui-build",
+        "move-ui-develop": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out -o ./src/ui",
         "move-ui-stage": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out/desktop_stage/ui -o ./src/ui",
         "move-ui-production": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out/desktop_production/ui -o ./src/ui",
         "bundle": "strawbees-desktop-packager-bundle",


### PR DESCRIPTION
Whenever `code-desktop` builds the `develop` branch, it should override the currently installed `code-ui` by the latest commit of the `develop` branch of `code-ui`. 

This should ensure fresh builds of `code-desktop` with the fresh features of `code-ui`. 