### PR TITLE
Build `develop` and `feature` branches with latest commit on `code-ui`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ platform:
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - cinst -y nsis
-  - SET PATH=C:\Program Files\NSIS\;C:\Program Files (x86)\NSIS\;%PATH%
-  - npm ci --only=production
+  - cmd: cinst -y nsis
+  - cmd: SET PATH=C:\Program Files\NSIS\;C:\Program Files (x86)\NSIS\;%PATH%
+  - cmd: npm ci --only=production
 
 # defined specific build configs for different branches
 for:
@@ -19,8 +19,6 @@ for:
       - master
   environment:
     NODE_ENV: production
-  install:
-    - cmd: npm ci --production
   build_script:
     - cmd: npm run move-ui-production
     - cmd: npm run bundle
@@ -29,29 +27,21 @@ for:
   branches:
     only:
       - develop
-  environment:
-    NODE_ENV: stage
-  install:
-      - cmd: git clone --single-branch --branch develop https://github.com/strawbees/code-ui.git
-      - cmd: cd code-ui
-      - cmd: npm link
-      - cmd: cd ..
-      - cmd: npm ci --production
-  build_script:
-    - cmd: set CONFIG=web_stage
-    - cmd: npm run build-ui
-    - cmd: npm run move-ui-develop
-    - cmd: npm run bundle
-    - cmd: npm run package
--
-  branches:
-    only:
       - /feature*/
   environment:
     NODE_ENV: stage
-  build_script:
+  before_build:
+    - cmd: git clone https://github.com/strawbees/code-ui.git
+    - cmd: cd code-ui
+    - cmd: git checkout develop
     - cmd: npm install
-    - cmd: npm run move-ui-stage
+    - cmd: npm link
+    - cmd: cd %APPVEYOR_BUILD_FOLDER%
+    - cmd: npm link "@strawbees/code-ui"
+  build_script:
+    - cmd: set CONFIG=desktop_stage
+    - cmd: npm run build-ui
+    - cmd: npm run move-ui-develop
     - cmd: npm run bundle
     - cmd: npm run package
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,10 @@ platform:
   - x86
   - x64
 
-install:
+init:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - cmd: cinst -y nsis
   - cmd: SET PATH=C:\Program Files\NSIS\;C:\Program Files (x86)\NSIS\;%PATH%
-  - cmd: npm ci --only=production
 
 # defined specific build configs for different branches
 for:
@@ -19,6 +18,8 @@ for:
       - master
   environment:
     NODE_ENV: production
+  install:
+    - cmd: npm ci --only=production
   build_script:
     - cmd: npm run move-ui-production
     - cmd: npm run bundle
@@ -30,7 +31,8 @@ for:
       - /feature*/
   environment:
     NODE_ENV: stage
-  before_build:
+  install:
+    - cmd: npm ci --only=production
     - cmd: git clone https://github.com/strawbees/code-ui.git
     - cmd: cd code-ui
     - cmd: git checkout develop

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "postinstall": "npm run install-src",
         "install-src": "cd src && npm install",
         "build-ui": "strawbees-code-ui-build",
-        "move-ui-develop": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out -o ./src/ui",
+        "move-ui-develop": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out/ui -o ./src/ui",
         "move-ui-stage": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out/desktop_stage/ui -o ./src/ui",
         "move-ui-production": "strawbees-desktop-packager-cpdir -s ./node_modules/@strawbees/code-ui/out/desktop_production/ui -o ./src/ui",
         "bundle": "strawbees-desktop-packager-bundle",


### PR DESCRIPTION
Whenever building the `develop` or `feature` branches, `code-desktop` will use the latest commit on `develop` branch of `code-ui`.

- Clone `code-ui` repository and enter cloned directory
- Switch to `develop` branch
- Install dependencies
- Run `npm link`
- Navigate to main project folder
- Run `npm link @strawbees/code-ui`
- Build and move UI to `src` with scripts provided on `package.json`