### PR TITLE
Feature/macos build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 dist
 src/ui

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js:
+- '11.2.0'
+os:
+- osx
+install:
+- npm ci --only=production
+cache:
+  directories:
+  - "$HOME/.npm"
+script:
+- npm run build
+branches:
+  only:
+    - master
+    - develop
+    - /feature*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,8 @@ branches:
   only:
     - master
     - develop
-    - /feature*/
+    - feature/macos-build
+addons:
+  artifacts:
+    paths: ./dist/versions
+    debug: true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ npm run move-ui-production
 npm build
 ```
 
+**Note**: Bump version on `src/package.json`.
+
 ## Signing and Deploying
 
 TODO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
     "name": "code-desktop",
-    "version": "2.0.0",
-    "lockfileVersion": 1,
     "requires": true,
+    "lockfileVersion": 1,
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.0.0",
@@ -910,9 +909,8 @@
             }
         },
         "@strawbees/desktop-packager": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@strawbees/desktop-packager/-/desktop-packager-0.3.2.tgz",
-            "integrity": "sha512-l5F7029RHxy7/YFGYBFGWAa1zVP1j2bXBJJUy6zJamIKKWnrMgl+Sgm/4jpu6YXItsLdumfESa3VWnuXWJGbMA==",
+            "version": "git+https://github.com/strawbees/desktop-packager.git#d096c4380b77b58a367e73cf2f7efa6801b4066a",
+            "from": "git+https://github.com/strawbees/desktop-packager.git#feature/macos-build",
             "requires": {
                 "adm-zip": "^0.4.13",
                 "appdmg": "^0.5.2",
@@ -2453,9 +2451,9 @@
             }
         },
         "commander": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
         },
         "common-tags": {
             "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "name": "code-desktop",
-    "version": "2.0.0",
     "description": "Desktop application for Strawbees CODE",
     "scripts": {
         "postinstall": "npm run install-src",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "license": "MIT",
     "dependencies": {
         "@strawbees/code-ui": "^1.4.0",
-        "@strawbees/desktop-packager": "^0.3.2"
+        "@strawbees/desktop-packager": "git+https://github.com/strawbees/desktop-packager.git#feature/macos-build"
     },
     "devDependencies": {
         "nw": "0.34.4-sdk"

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "strawbeescode",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"display-name": "Strawbees CODE",
 	"executable-name": "Strawbees CODE",
 	"publisher": "Strawbees AB",


### PR DESCRIPTION
Allow `code-desktop` to be automatically built by Travis CI.

The main change in this PR, except the `.travis.yml` configuration file, is that the app version was moved from the `package.json` to `src/package.json` for ease on the build process.